### PR TITLE
fix: connection string should always sensitive value

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+HASH_SECRET=this-is-hash-secret

--- a/__tests__/AppSettingsBase.test.ts
+++ b/__tests__/AppSettingsBase.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals';
+import { expect, test, describe } from '@jest/globals';
 import { DefaultSensitiveEnum, DefaultSlotSettingEnum, ISwapAppService } from '../src/interfaces';
 import AppSettingsBase, { AppSettingsType, IAppSettingOption } from '../src/core/AppSettingsBase';
 const globalConfig = {
@@ -6,13 +6,13 @@ const globalConfig = {
   resourceGroup: 'resourceGroup name',
   slot: 'production',
   targetSlot: 'staging',
-  defaultSensitive: DefaultSensitiveEnum.required,
-  defaultSlotSetting: DefaultSlotSettingEnum.required,
 };
 
 test('AppSettingsBase init object should set source, target appSettings and default options', () => {
   const swapAppService: ISwapAppService = {
     ...globalConfig,
+    defaultSensitive: DefaultSensitiveEnum.required,
+    defaultSlotSetting: DefaultSlotSettingEnum.required,
     connectionStrings: [],
     appSettings: [
       {
@@ -56,32 +56,89 @@ class AppSettingsBaseTest extends AppSettingsBase {
   }
 }
 
-test('AppSettingsBase.list().validate().fullfill().apply().mask() should set slotSetting and mask value as a secret', async () => {
-  const swapAppService: ISwapAppService = {
-    ...globalConfig,
-    connectionStrings: [],
-    appSettings: [
+describe('AppSettingsBaseTest', () => {
+  test('AppSettingsBase.list().validate().fullfill().apply().mask() should set slotSetting and mask value as a secret', async () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.required,
+      defaultSlotSetting: DefaultSlotSettingEnum.required,
+      connectionStrings: [],
+      appSettings: [
+        {
+          name: 'data',
+          sensitive: true,
+          slotSetting: true,
+        },
+      ],
+    };
+    const appSettingsBase = new AppSettingsBaseTest(swapAppService);
+    (await appSettingsBase.list()).validate().fullfill().apply().mask();
+    expect(appSettingsBase.getTarget()).toStrictEqual([
       {
         name: 'data',
-        sensitive: true,
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
         slotSetting: true,
       },
-    ],
-  };
-  const appSettingsBase = new AppSettingsBaseTest(swapAppService);
-  (await appSettingsBase.list()).validate().fullfill().apply().mask();
-  expect(appSettingsBase.getTarget()).toStrictEqual([
-    {
-      name: 'data',
-      value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
-      slotSetting: true,
-    },
-  ]);
-  expect(appSettingsBase.getSource()).toStrictEqual([
-    {
-      name: 'data',
-      value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
-      slotSetting: true,
-    },
-  ]);
+    ]);
+    expect(appSettingsBase.getSource()).toStrictEqual([
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: true,
+      },
+    ]);
+  });
+});
+
+class ConnectionStringTest extends AppSettingsBase {
+  constructor(swapAppService: ISwapAppService, options?: Partial<IAppSettingOption>) {
+    super(swapAppService, AppSettingsType.ConnectionStrings, options);
+  }
+
+  /** @override */
+  public async list() {
+    this.source = [
+      {
+        name: 'data',
+        value: 'value',
+        slotSetting: false,
+      },
+    ];
+    this.target = [
+      {
+        name: 'data',
+        value: 'value',
+        slotSetting: false,
+      },
+    ];
+    return this;
+  }
+}
+
+describe('ConnectionStringTest', () => {
+  test('AppSettingsBase.loadAppSettings() should mask value as a secret for connectionStrings', async () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.true,
+      defaultSlotSetting: DefaultSlotSettingEnum.true,
+      connectionStrings: [],
+      appSettings: [],
+    };
+    const appSettingsBase = new ConnectionStringTest(swapAppService);
+    await appSettingsBase.loadAppSettings();
+    expect(appSettingsBase.getTarget()).toStrictEqual([
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: false,
+      },
+    ]);
+    expect(appSettingsBase.getSource()).toStrictEqual([
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: false,
+      },
+    ]);
+  });
 });

--- a/__tests__/AppSettingsMasking.test.ts
+++ b/__tests__/AppSettingsMasking.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals';
+import { expect, test, describe } from '@jest/globals';
 import { AppSettingsType } from '../src/core/AppSettingsBase';
 import AppSettingsMasking from '../src/core/AppSettingsMasking';
 import { DefaultSensitiveEnum, DefaultSlotSettingEnum, IAppSetting, ISwapAppService } from '../src/interfaces';
@@ -8,138 +8,177 @@ const globalConfig = {
   resourceGroup: 'resourceGroup name',
   slot: 'production',
   targetSlot: 'staging',
-  defaultSensitive: DefaultSensitiveEnum.required,
-  defaultSlotSetting: DefaultSlotSettingEnum.required,
+  defaultSlotSetting: DefaultSlotSettingEnum.required, // This will not effect in test
 };
 
-test('AppSettingsMasking.mask() (AppSettings) should return hash value in appSettings if sensitive is true', () => {
-  const swapAppService: ISwapAppService = {
-    ...globalConfig,
-    connectionStrings: [],
-    appSettings: [
+describe('App Setting Type', () => {
+  test('AppSettingsMasking.mask() (AppSettings) should return hash value in appSettings if sensitive is true', () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.required,
+      connectionStrings: [],
+      appSettings: [
+        {
+          name: 'data',
+          sensitive: true,
+          slotSetting: true,
+        },
+      ],
+    };
+
+    const appSettings: IAppSetting[] = [
       {
         name: 'data',
-        sensitive: true,
+        value: 'value',
         slotSetting: true,
       },
-    ],
-  };
+    ];
 
-  const appSettings: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'value',
-      slotSetting: true,
-    },
-  ];
+    const expected: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: true,
+      },
+    ];
 
-  const expected: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
-      slotSetting: true,
-    },
-  ];
+    const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.AppSettings);
+    expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  });
 
-  const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.AppSettings);
-  expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  test('AppSettingsMasking.mask() (AppSettings) should return actual value in appSettings if sensitive is false', () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.required,
+
+      connectionStrings: [],
+      appSettings: [
+        {
+          name: 'data',
+          sensitive: false,
+          slotSetting: true,
+        },
+      ],
+    };
+
+    const appSettings: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'value',
+        slotSetting: true,
+      },
+    ];
+
+    const expected: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'value',
+        slotSetting: true,
+      },
+    ];
+
+    const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.AppSettings);
+    expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  });
 });
 
-test('AppSettingsMasking.mask() (AppSettings) should return actual value in appSettings if sensitive is false', () => {
-  const swapAppService: ISwapAppService = {
-    ...globalConfig,
-    connectionStrings: [],
-    appSettings: [
+describe('Connection String Type', () => {
+  test('AppSettingsMasking.mask() (connectionStrings) should return always hash value in connectionStrings if sensitive is true', () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.required,
+
+      connectionStrings: [
+        {
+          name: 'data',
+          sensitive: true,
+          slotSetting: true,
+        },
+      ],
+      appSettings: [],
+    };
+
+    const appSettings: IAppSetting[] = [
       {
         name: 'data',
-        sensitive: false,
+        value: 'value',
         slotSetting: true,
       },
-    ],
-  };
+    ];
 
-  const appSettings: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'value',
-      slotSetting: true,
-    },
-  ];
-
-  const expected: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'value',
-      slotSetting: true,
-    },
-  ];
-
-  const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.AppSettings);
-  expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
-});
-
-test('AppSettingsMasking.mask() (connectionStrings) should return always hash value in connectionStrings if sensitive is true', () => {
-  const swapAppService: ISwapAppService = {
-    ...globalConfig,
-    connectionStrings: [
+    const expected: IAppSetting[] = [
       {
         name: 'data',
-        sensitive: true,
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
         slotSetting: true,
       },
-    ],
-    appSettings: [],
-  };
+    ];
 
-  const appSettings: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'value',
-      slotSetting: true,
-    },
-  ];
+    const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.ConnectionStrings);
+    expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  });
 
-  const expected: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
-      slotSetting: true,
-    },
-  ];
+  test('AppSettingsMasking.mask() (connectionStrings) should return always hash value in connectionStrings if sensitive is false', () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.required,
 
-  const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.ConnectionStrings);
-  expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
-});
+      connectionStrings: [
+        {
+          name: 'data',
+          sensitive: false,
+          slotSetting: true,
+        },
+      ],
+      appSettings: [],
+    };
 
-test('AppSettingsMasking.mask() (connectionStrings) should return always hash value in connectionStrings if sensitive is false', () => {
-  const swapAppService: ISwapAppService = {
-    ...globalConfig,
-    connectionStrings: [
+    const appSettings: IAppSetting[] = [
       {
         name: 'data',
-        sensitive: false,
+        value: 'value',
         slotSetting: true,
       },
-    ],
-    appSettings: [],
-  };
+    ];
 
-  const appSettings: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'value',
-      slotSetting: true,
-    },
-  ];
+    const expected: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: true,
+      },
+    ];
 
-  const expected: IAppSetting[] = [
-    {
-      name: 'data',
-      value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
-      slotSetting: true,
-    },
-  ];
+    const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.ConnectionStrings);
+    expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  });
 
-  const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.ConnectionStrings);
-  expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  test('AppSettingsMasking.mask() (connectionStrings) should return always hash value in connectionStrings if defaultSensitive is true, and no specific config for sensitive', () => {
+    const swapAppService: ISwapAppService = {
+      ...globalConfig,
+      defaultSensitive: DefaultSensitiveEnum.true,
+
+      connectionStrings: [],
+      appSettings: [],
+    };
+
+    const appSettings: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'value',
+        slotSetting: true,
+      },
+    ];
+
+    const expected: IAppSetting[] = [
+      {
+        name: 'data',
+        value: 'ks3l7pl3EGX1QjFFGkZTcQcdizooEKftwwd8/sZ+o4aasgytauZM4N0hz30fTVkpI821ZoMzii3yMw9H6Sz9PQ==',
+        slotSetting: true,
+      },
+    ];
+
+    const appSettingsMasking = new AppSettingsMasking(swapAppService, AppSettingsType.ConnectionStrings);
+    expect(appSettingsMasking.mask(appSettings, 'staging')).toStrictEqual(expected);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-action",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-action",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/src/commands/GetDeploySlots.ts
+++ b/src/commands/GetDeploySlots.ts
@@ -42,7 +42,7 @@ export class GetDeploySlots {
     swapAppService: ISwapAppService
   ): Promise<IAppSettingsAllSlots> {
     const appSetting = AppSettingsProviderFactory.getAppSettingsProvider(type, swapAppService);
-    (await appSetting.list()).validate().fullfill().mask();
+    await appSetting.loadAppSettings();
 
     const swapAppSettings = new SwapAppSettings(swapAppService);
     return {

--- a/src/core/AppSettingsBase.ts
+++ b/src/core/AppSettingsBase.ts
@@ -79,6 +79,14 @@ export default class AppSettingsBase {
     return this;
   }
 
+  /**
+   * Main entry for this class
+   */
+
+  public async loadAppSettings() {
+    (await this.list()).validate().fullfill().mask();
+  }
+
   public setWebAppSourceSlot() {
     this.setWebApp(this.source, this.swapAppService.slot);
   }

--- a/src/core/AppSettingsMasking.ts
+++ b/src/core/AppSettingsMasking.ts
@@ -18,8 +18,15 @@ export default class AppSettingsMasking {
         ? this.swapAppService.connectionStrings
         : this.swapAppService.appSettings;
 
+    if (this.type === AppSettingsType.ConnectionStrings) {
+      for (const appSetting of appSettings) {
+        appSetting.value = hashValue(appSetting.value);
+      }
+      return appSettings;
+    }
+
     for (const swapAppSetting of swapAppSettings) {
-      if (swapAppSetting.sensitive === true || this.type === AppSettingsType.ConnectionStrings) {
+      if (swapAppSetting.sensitive === true) {
         const found = findAppSettingName(swapAppSetting.name, appSettings);
         if (found >= 0) {
           const foundAppSetting = appSettings[found];


### PR DESCRIPTION
This PR will fix bug in case connection string should always hash value (sensitive)